### PR TITLE
Fix data corruption detected on Pi3

### DIFF
--- a/firmware/usb.c
+++ b/firmware/usb.c
@@ -391,7 +391,7 @@ void usb_interrupt_handler() {
 						set_all_leds(0) ;
 						red_led = LED_AUTO ; }
 
-					if ( EP1_OUTbuffer[3] == 65 ) {
+					if ( !(Interfaces[1].Input.Stat & UOWN) ) {
 
 						Interfaces[1].Input.Cnt = 8 ;
 						Interfaces[1].Input.ADDR = 0x2084 ;


### PR DESCRIPTION
When replacing the IN buffer at the end of the OUT transaction we are potentially overwritting a buffer in the control of SIE.

After this simple fix no more error detected.
